### PR TITLE
Dropped support for Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Requirements
 
         * Ubuntu
 
-            * Trusty (14.04)
             * Xenial (16.04)
             * Bionic (18.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,6 @@ galaxy_info:
         - 31
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
         - bionic
     - name: Debian

--- a/molecule/ubuntu_min/molecule.yml
+++ b/molecule/ubuntu_min/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible_role_helm_ubuntu_min
-    image: ubuntu:14.04
+    image: ubuntu:16.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
The included Python version doesn't support SNI, which is needed for the get.helm.sh CDN.