### PR TITLE
Added helm_architecture role variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ are shown below):
 # Helm version number
 helm_version: '3.2.0'
 
+# The CPU architecture of the Helm executable to install
+helm_architecture: 'amd64'
+
 # Mirror to download Helm from
 helm_mirror: 'https://get.helm.sh'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,4 +13,3 @@ helm_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.an
 
 # The CPU architecture of the Helm redistributable
 helm_architecture: 'amd64'
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # Helm version number
 helm_version: '3.2.0'
 
+# The CPU architecture of the Helm executable to install
+helm_architecture: 'amd64'
+
 # Mirror to download Helm from
 helm_mirror: 'https://get.helm.sh'
 
@@ -10,6 +13,3 @@ helm_install_dir: '/usr/local/share/helm'
 
 # Directory to store files downloaded for Helm
 helm_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
-
-# The CPU architecture of the Helm redistributable
-helm_architecture: 'amd64'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,7 @@ helm_install_dir: '/usr/local/share/helm'
 
 # Directory to store files downloaded for Helm
 helm_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
+
+# The CPU architecture of the Helm redistributable
+helm_architecture: 'amd64'
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,8 +2,5 @@
 # The OS of the Helm redistributable
 helm_os: 'linux'
 
-# The CPU architecture of the Helm redistributable
-helm_architecture: 'amd64'
-
 # File name of the Helm redistributable file
 helm_redis_filename: 'helm-v{{ helm_version }}-{{ helm_os }}-{{ helm_architecture }}.tar.gz'


### PR DESCRIPTION
To allow the CPU architecture to be specified for the Helm executable to install.