### PR TITLE
Dropped support for Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Requirements
 
         * Debian
 
-            * Stretch (9)
             * Buster (10)
             * Bullseye (11)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
         - focal
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
     - name: opensuse

--- a/molecule/debian_min/molecule.yml
+++ b/molecule/debian_min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible_role_helm_debian_min
-    image: debian:9
+    image: debian:10
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Debian ended LTS support on 01 Jul 2022.